### PR TITLE
Allow Check on incomplete drag-and-drop answers

### DIFF
--- a/src/features/exercises/components/DragDropCombination.tsx
+++ b/src/features/exercises/components/DragDropCombination.tsx
@@ -1,10 +1,12 @@
 "use client";
 
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { Box, IconButton, Typography } from "@mui/material";
 import VolumeUpRoundedIcon from "@mui/icons-material/VolumeUpRounded";
 import GraphicEqRoundedIcon from "@mui/icons-material/GraphicEqRounded";
 import ImageNotSupportedRoundedIcon from "@mui/icons-material/ImageNotSupportedRounded";
+
+import { isCorrectPlacement } from "../dragDropPlacement";
 import SelfRecordButton from "./SelfRecordButton";
 
 // Grammar-lesson drag-and-drop: build the correct word/phrase by dragging
@@ -49,15 +51,7 @@ const DragDropCombination: React.FC<Props> = ({
   const tileAudioRef = useRef<HTMLAudioElement | null>(null);
 
   const placedTiles = placedIndices.map((i) => options[i]);
-  const isComplete = placedIndices.length === correctSequence.length;
-  const isCorrect = useMemo(
-    () =>
-      isComplete &&
-      placedTiles.every(
-        (t, i) => t.trim().toLowerCase() === (correctSequence[i] ?? "").trim().toLowerCase()
-      ),
-    [placedTiles, correctSequence, isComplete]
-  );
+  const isCorrect = isCorrectPlacement(placedTiles, correctSequence);
   // Positive reinforcement, shown once the sequence is checked and correct —
   // the whole-word clip and the per-tile clips are gated the same way.
   const showResult = checked && isCorrect;
@@ -141,7 +135,6 @@ const DragDropCombination: React.FC<Props> = ({
   };
 
   const handleCheck = () => {
-    if (!isComplete) return;
     setChecked(true);
     onResult?.({
       result: isCorrect ? "correct" : "incorrect",
@@ -465,20 +458,19 @@ const DragDropCombination: React.FC<Props> = ({
         <Box
           component="button"
           onClick={handleCheck}
-          disabled={!isComplete}
           sx={{
             px: 3,
             py: 1.25,
             borderRadius: 999,
             border: "none",
-            bgcolor: isComplete ? "#B43D20" : "rgba(0,0,0,0.08)",
-            color: isComplete ? "#fff" : "rgba(0,0,0,0.35)",
+            bgcolor: "#B43D20",
+            color: "#fff",
             fontWeight: 700,
             fontSize: "0.9rem",
-            cursor: isComplete ? "pointer" : "default",
+            cursor: "pointer",
             transition: "all 0.2s",
-            boxShadow: isComplete ? "0 4px 14px rgba(180,61,32,0.35)" : "none",
-            "&:hover": isComplete ? { bgcolor: "#9D351C" } : {},
+            boxShadow: "0 4px 14px rgba(180,61,32,0.35)",
+            "&:hover": { bgcolor: "#9D351C" },
           }}
         >
           Check

--- a/src/features/exercises/dragDropPlacement.test.ts
+++ b/src/features/exercises/dragDropPlacement.test.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { isCorrectPlacement } from "./dragDropPlacement";
+
+/*
+ * Length is part of the grade. An empty, short, or overfilled placement is
+ * incorrect — not "not yet ready to check".
+ */
+
+test("an exact match is correct", () => {
+  assert.equal(isCorrectPlacement(["あ", "お"], ["あ", "お"]), true);
+});
+
+test("too few tiles is incorrect", () => {
+  assert.equal(isCorrectPlacement(["あ"], ["あ", "お"]), false);
+  assert.equal(isCorrectPlacement([], ["あ", "お"]), false);
+});
+
+test("too many tiles is incorrect", () => {
+  assert.equal(isCorrectPlacement(["あ", "お", "い"], ["あ", "お"]), false);
+});
+
+test("the right tiles in the wrong order are incorrect", () => {
+  assert.equal(isCorrectPlacement(["お", "あ"], ["あ", "お"]), false);
+});
+
+test("a matching prefix of a longer answer is still incorrect", () => {
+  assert.equal(isCorrectPlacement(["あ", "お"], ["あ", "お", "い"]), false);
+});
+
+test("comparison trims and ignores case", () => {
+  assert.equal(isCorrectPlacement(["  Ha  ", "Yo"], ["ha", "yo"]), true);
+});

--- a/src/features/exercises/dragDropPlacement.ts
+++ b/src/features/exercises/dragDropPlacement.ts
@@ -1,0 +1,16 @@
+function normalizeTile(tile: string): string {
+  return tile.trim().toLowerCase();
+}
+
+/**
+ * Whether the tiles in the drop box match the authored answer, in order.
+ *
+ * Length is part of the answer: too few or too many tiles is incorrect.
+ * Comparison is trimmed and case-insensitive.
+ */
+export function isCorrectPlacement(placed: string[], correct: string[]): boolean {
+  if (placed.length !== correct.length) return false;
+  return placed.every(
+    (tile, i) => normalizeTile(tile) === normalizeTile(correct[i] ?? "")
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Change

Learners can press **Check** on a drag-and-drop (`buildSentence`) screen even when the drop box does not have the expected number of tiles.

Too few, too many, or the right tiles in the wrong order all grade as **incorrect**. Only the exact sequence (trimmed, case-insensitive) grades as correct. Reference audio still appears only after a correct check.

This reverses the earlier “keep Check disabled until the box is full” behavior so an incomplete attempt can actually be submitted.

## How to try it

Open a grammar drag-and-drop screen (for example Hiragana Lesson 1’s あお puzzle, bank `あ い う え お`, answer `あ お`):

1. Drop only `あ` and press Check — should mark incorrect, not stay greyed out.
2. Drop extra tiles beyond the answer and press Check — incorrect.
3. Drop `あ` then `お` and press Check — correct, audio appears as before.

## Checks

- `npm test` (111 pass, including the new placement cases)
- `npm run typecheck`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-84550dda-85ba-4259-8e9d-3912242f173c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-84550dda-85ba-4259-8e9d-3912242f173c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

