### PR TITLE
Improve reading/writing practice: review nav, listen-and-choose, and drag-drop

### DIFF
--- a/content/snapshot/lessons.json
+++ b/content/snapshot/lessons.json
@@ -232,29 +232,25 @@
           "components": [
             {
               "id": "6a83f02bb78e2c76b66a8657",
-              "instructions": "Listen and choose the character you hear",
+              "instructions": "Which situation matches this phrase?",
               "term": {
-                "$ref": "あ-ア",
+                "$ref": "あお",
                 "$collection": "terms"
               },
-              "answerWith": "text",
+              "answerWith": "image",
               "blockName": null,
               "blockType": "listenAndChoose",
               "distractors": [
                 {
-                  "$ref": "い-イ",
+                  "$ref": "うえ",
                   "$collection": "terms"
                 },
                 {
-                  "$ref": "う-ウ",
+                  "$ref": "あう",
                   "$collection": "terms"
                 },
                 {
-                  "$ref": "え-エ",
-                  "$collection": "terms"
-                },
-                {
-                  "$ref": "お-オ",
+                  "$ref": "おおい",
                   "$collection": "terms"
                 }
               ]
@@ -267,29 +263,25 @@
           "components": [
             {
               "id": "6a83f02bb78e2c76b66a8658",
-              "instructions": "Listen and choose the character you hear",
+              "instructions": "Which situation matches this phrase?",
               "term": {
-                "$ref": "い-イ",
+                "$ref": "うえ",
                 "$collection": "terms"
               },
-              "answerWith": "text",
+              "answerWith": "image",
               "blockName": null,
               "blockType": "listenAndChoose",
               "distractors": [
                 {
-                  "$ref": "あ-ア",
+                  "$ref": "あお",
                   "$collection": "terms"
                 },
                 {
-                  "$ref": "う-ウ",
+                  "$ref": "あう",
                   "$collection": "terms"
                 },
                 {
-                  "$ref": "え-エ",
-                  "$collection": "terms"
-                },
-                {
-                  "$ref": "お-オ",
+                  "$ref": "おおい",
                   "$collection": "terms"
                 }
               ]
@@ -302,29 +294,25 @@
           "components": [
             {
               "id": "6a83f02bb78e2c76b66a8659",
-              "instructions": "Listen and choose the character you hear",
+              "instructions": "Which situation matches this phrase?",
               "term": {
-                "$ref": "う-ウ",
+                "$ref": "あう",
                 "$collection": "terms"
               },
-              "answerWith": "text",
+              "answerWith": "image",
               "blockName": null,
               "blockType": "listenAndChoose",
               "distractors": [
                 {
-                  "$ref": "あ-ア",
+                  "$ref": "あお",
                   "$collection": "terms"
                 },
                 {
-                  "$ref": "い-イ",
+                  "$ref": "うえ",
                   "$collection": "terms"
                 },
                 {
-                  "$ref": "え-エ",
-                  "$collection": "terms"
-                },
-                {
-                  "$ref": "お-オ",
+                  "$ref": "おおい",
                   "$collection": "terms"
                 }
               ]
@@ -337,29 +325,25 @@
           "components": [
             {
               "id": "6a83f02bb78e2c76b66a865a",
-              "instructions": "Listen and choose the character you hear",
+              "instructions": "Which situation matches this phrase?",
               "term": {
-                "$ref": "え-エ",
+                "$ref": "おおい",
                 "$collection": "terms"
               },
-              "answerWith": "text",
+              "answerWith": "image",
               "blockName": null,
               "blockType": "listenAndChoose",
               "distractors": [
                 {
-                  "$ref": "あ-ア",
+                  "$ref": "あお",
                   "$collection": "terms"
                 },
                 {
-                  "$ref": "い-イ",
+                  "$ref": "うえ",
                   "$collection": "terms"
                 },
                 {
-                  "$ref": "う-ウ",
-                  "$collection": "terms"
-                },
-                {
-                  "$ref": "お-オ",
+                  "$ref": "あう",
                   "$collection": "terms"
                 }
               ]

--- a/src/app/(app)/(player)/lessons/[slug]/review/page.tsx
+++ b/src/app/(app)/(player)/lessons/[slug]/review/page.tsx
@@ -1,6 +1,11 @@
 import { redirect } from "next/navigation";
 
-import { getDraftLesson, getLessonBySlug } from "@/lib/content/content";
+import {
+  getDraftLesson,
+  getDraftNeighborLessonReviewHref,
+  getLessonBySlug,
+  getNeighborLessonReviewHref,
+} from "@/lib/content/content";
 import { getPreviewEditor } from "@/lib/session";
 import { collectLessonTerms } from "@/lib/content/lessonTerms";
 import TermReviewPage from "@/features/learning/components/TermReviewPage";
@@ -30,6 +35,17 @@ export default async function Page({
   if (!lesson) redirect("/dashboard");
 
   const terms = collectLessonTerms(lesson);
+  const [prevHref, nextHref] = await Promise.all(
+    editor
+      ? [
+          getDraftNeighborLessonReviewHref(lesson, editor, "prev"),
+          getDraftNeighborLessonReviewHref(lesson, editor, "next"),
+        ]
+      : [
+          getNeighborLessonReviewHref(lesson, "prev"),
+          getNeighborLessonReviewHref(lesson, "next"),
+        ]
+  );
 
-  return <TermReviewPage lesson={lesson} terms={terms} />;
+  return <TermReviewPage lesson={lesson} terms={terms} prevHref={prevHref} nextHref={nextHref} />;
 }

--- a/src/features/exercises/components/DragDropCombination.tsx
+++ b/src/features/exercises/components/DragDropCombination.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useEffect, useMemo, useRef, useState } from "react";
-import { Box, IconButton, Typography } from "@mui/material";
+import { Box, IconButton, Typography, type SxProps, type Theme } from "@mui/material";
 import VolumeUpRoundedIcon from "@mui/icons-material/VolumeUpRounded";
 import GraphicEqRoundedIcon from "@mui/icons-material/GraphicEqRounded";
 import ImageNotSupportedRoundedIcon from "@mui/icons-material/ImageNotSupportedRounded";
@@ -12,7 +12,9 @@ import SelfRecordButton from "./SelfRecordButton";
 // fixed box per expected piece — the box just grows as tiles are added).
 // Tiles size themselves to their own text (padding-based, no fixed
 // width/height), since fragments vary a lot in length ("ha" vs "arigatou").
-type DragPayload = { source: "bank" | "box"; index: number };
+type DragPayload =
+  | { source: "bank"; option: number }
+  | { source: "box"; option: number; placedAt: number };
 
 type Props = {
   prompt?: string;
@@ -24,6 +26,29 @@ type Props = {
   tileAudio?: (string | undefined)[];
   onResult?: (r: { result: "correct" | "incorrect"; detail?: any }) => void;
 };
+
+function dropEffect(source: DragPayload["source"] | undefined): "copy" | "move" {
+  return source === "bank" ? "copy" : "move";
+}
+
+function tileHearButtonSx(hasAudio: boolean, isPlaying: boolean): SxProps<Theme> {
+  const base = {
+    width: 36,
+    height: 36,
+    transition: "all 0.2s",
+    "&.Mui-disabled": { bgcolor: "rgba(0,0,0,0.08)", color: "rgba(0,0,0,0.3)" },
+  };
+  if (!hasAudio) {
+    return { ...base, bgcolor: "rgba(0,0,0,0.08)", color: "rgba(0,0,0,0.3)", border: "none" };
+  }
+  return {
+    ...base,
+    bgcolor: isPlaying ? "rgba(180,61,32,0.08)" : "#B43D20",
+    color: isPlaying ? "#B43D20" : "#fff",
+    border: isPlaying ? "2px solid #B43D20" : "none",
+    "&:hover": { bgcolor: isPlaying ? "rgba(180,61,32,0.12)" : "#9D351C" },
+  };
+}
 
 const DragDropCombination: React.FC<Props> = ({
   prompt = "Drag the tiles into the correct order",
@@ -67,13 +92,10 @@ const DragDropCombination: React.FC<Props> = ({
   // piece" above a row of inert grey buttons.
   const showTileAudio = showResult && Boolean(tileAudio?.some(Boolean));
 
-  const bankIndices = options.map((_, i) => i).filter((i) => !placedIndices.includes(i));
-
-  const onDragStart = (e: React.DragEvent<HTMLDivElement>, source: "bank" | "box", index: number) => {
-    const payload: DragPayload = { source, index };
+  const onDragStart = (e: React.DragEvent<HTMLDivElement>, payload: DragPayload) => {
     dragPayloadRef.current = payload;
     e.dataTransfer.setData("application/json", JSON.stringify(payload));
-    e.dataTransfer.effectAllowed = "move";
+    e.dataTransfer.effectAllowed = dropEffect(payload.source);
   };
 
   const readPayload = (e: React.DragEvent<HTMLDivElement>): DragPayload | null => {
@@ -85,22 +107,35 @@ const DragDropCombination: React.FC<Props> = ({
     }
   };
 
-  // Moves the dragged tile (from the bank, or already in the box) so it ends
-  // up at `targetPos` within the placed sequence — this is what actually
-  // lets you reorder tiles you've already placed, not just append/remove.
+  // Copies a bank tile into the placed sequence, or moves one already in the
+  // box. Bank tiles are not consumed: an answer that repeats a character
+  // ("おおい") pulls the same お twice rather than needing a duplicate in
+  // the bank. Reorder uses `placedAt` so two copies of the same option stay
+  // distinct slots.
   const moveToPosition = (payload: DragPayload, targetPos: number) => {
     setChecked(false);
     setPlacedIndices((prev) => {
       const next = [...prev];
       let pos = targetPos;
-      if (payload.source === "box") {
-        const fromPos = next.indexOf(payload.index);
-        if (fromPos === -1) return next;
-        next.splice(fromPos, 1);
-        if (fromPos < pos) pos -= 1;
+      switch (payload.source) {
+        case "box": {
+          if (payload.placedAt < 0 || payload.placedAt >= next.length) return next;
+          if (next[payload.placedAt] !== payload.option) return next;
+          next.splice(payload.placedAt, 1);
+          if (payload.placedAt < pos) pos -= 1;
+          break;
+        }
+        case "bank": {
+          if (next.length >= correctSequence.length) return next;
+          break;
+        }
+        default: {
+          const _exhaustive: never = payload;
+          return _exhaustive;
+        }
       }
       pos = Math.max(0, Math.min(pos, next.length));
-      next.splice(pos, 0, payload.index);
+      next.splice(pos, 0, payload.option);
       return next;
     });
   };
@@ -126,18 +161,17 @@ const DragDropCombination: React.FC<Props> = ({
     moveToPosition(payload, beforeIndexInPlaced);
   };
 
+  const removePlacedAt = (placedAt: number) => {
+    setChecked(false);
+    setPlacedIndices((prev) => prev.filter((_, i) => i !== placedAt));
+  };
+
   const onDropBank = (e: React.DragEvent<HTMLDivElement>) => {
     e.preventDefault();
     setBankDragOver(false);
     const payload = readPayload(e);
     if (!payload || payload.source !== "box") return;
-    setChecked(false);
-    setPlacedIndices((prev) => prev.filter((i) => i !== payload.index));
-  };
-
-  const removeTile = (index: number) => {
-    setChecked(false);
-    setPlacedIndices((prev) => prev.filter((i) => i !== index));
+    removePlacedAt(payload.placedAt);
   };
 
   const handleCheck = () => {
@@ -278,17 +312,13 @@ const DragDropCombination: React.FC<Props> = ({
         </Box>
       )}
 
-      {/* One button per tile, in the order they were placed — same
-          reinforcement moment as the reference audio above, but for each
-          piece that went into the answer. A tile with no recording yet still
-          gets a button, greyed out and inert, matching the filler-button
-          convention used everywhere else audio can be missing. */}
+      {/* After a correct check: one hear-button per option, including leftover
+          distractors. Missing clips stay as greyed-out filler buttons. */}
       {showTileAudio && (
         <Box sx={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 0.75 }}>
           <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap", justifyContent: "center" }}>
-            {placedIndices.map((idx) => {
-              const src = tileAudio?.[idx];
-              const hasAudio = Boolean(src);
+            {options.map((label, idx) => {
+              const hasAudio = Boolean(tileAudio?.[idx]);
               const isPlayingThis = playingTile === idx;
               return (
                 <Box
@@ -298,17 +328,8 @@ const DragDropCombination: React.FC<Props> = ({
                   <IconButton
                     onClick={() => playTile(idx)}
                     disabled={!hasAudio}
-                    aria-label={`Play audio for ${options[idx]}`}
-                    sx={{
-                      width: 36,
-                      height: 36,
-                      bgcolor: hasAudio ? (isPlayingThis ? "rgba(180,61,32,0.08)" : "#B43D20") : "rgba(0,0,0,0.08)",
-                      color: hasAudio ? (isPlayingThis ? "#B43D20" : "#fff") : "rgba(0,0,0,0.3)",
-                      border: hasAudio && isPlayingThis ? "2px solid #B43D20" : "none",
-                      "&:hover": hasAudio ? { bgcolor: isPlayingThis ? "rgba(180,61,32,0.12)" : "#9D351C" } : {},
-                      "&.Mui-disabled": { bgcolor: "rgba(0,0,0,0.08)", color: "rgba(0,0,0,0.3)" },
-                      transition: "all 0.2s",
-                    }}
+                    aria-label={`Play audio for ${label}`}
+                    sx={tileHearButtonSx(hasAudio, isPlayingThis)}
                   >
                     {isPlayingThis ? (
                       <GraphicEqRoundedIcon sx={{ fontSize: "1.1rem" }} />
@@ -317,7 +338,7 @@ const DragDropCombination: React.FC<Props> = ({
                     )}
                   </IconButton>
                   <Typography sx={{ fontSize: "0.7rem", color: "text.secondary", fontWeight: 700 }}>
-                    {options[idx]}
+                    {label}
                   </Typography>
                 </Box>
               );
@@ -336,6 +357,7 @@ const DragDropCombination: React.FC<Props> = ({
         aria-label="Drop the tiles here in order"
         onDragOver={(e) => {
           e.preventDefault();
+          e.dataTransfer.dropEffect = dropEffect(dragPayloadRef.current?.source);
           setBoxDragOver(true);
         }}
         onDragLeave={() => setBoxDragOver(false)}
@@ -374,13 +396,14 @@ const DragDropCombination: React.FC<Props> = ({
         ) : (
           placedIndices.map((idx, pos) => (
             <Box
-              key={`placed-${idx}`}
+              key={`placed-${pos}-${idx}`}
               draggable
-              onDragStart={(e) => onDragStart(e, "box", idx)}
-              onDoubleClick={() => removeTile(idx)}
+              onDragStart={(e) => onDragStart(e, { source: "box", option: idx, placedAt: pos })}
+              onDoubleClick={() => removePlacedAt(pos)}
               onDragOver={(e) => {
                 e.preventDefault();
                 e.stopPropagation();
+                e.dataTransfer.dropEffect = dropEffect(dragPayloadRef.current?.source);
                 setBoxDragOver(true);
               }}
               onDrop={(e) => onDropOnTile(e, pos)}
@@ -405,61 +428,63 @@ const DragDropCombination: React.FC<Props> = ({
         )}
       </Box>
 
-      {/* Bank — remaining, not-yet-placed tiles */}
-      <Box
-        sx={{
-          display: "flex",
-          gap: 1.25,
-          p: 1.5,
-          borderRadius: "14px",
-          bgcolor: bankDragOver ? "rgba(96,165,250,0.08)" : "#F9F7F4",
-          border: `1px solid ${bankDragOver ? "#60A5FA" : "rgba(0,0,0,0.08)"}`,
-          minHeight: 76,
-          flexWrap: "wrap",
-          justifyContent: "center",
-          width: "100%",
-          transition: "border-color 0.2s, background-color 0.2s",
-        }}
-        onDragOver={(e) => {
-          e.preventDefault();
-          setBankDragOver(true);
-        }}
-        onDragLeave={() => setBankDragOver(false)}
-        onDrop={onDropBank}
-      >
-        {bankIndices.map((idx) => (
-          <Box
-            key={`bank-${idx}`}
-            draggable
-            onDragStart={(e) => onDragStart(e, "bank", idx)}
-            title="Drag to the box above"
-            sx={{
-              px: 2.5,
-              py: 1.25,
-              border: "2px solid rgba(0,0,0,0.1)",
-              borderRadius: "12px",
-              cursor: "grab",
-              fontSize: { xs: "0.95rem", sm: "1.05rem" },
-              fontWeight: 700,
-              whiteSpace: "nowrap",
-              userSelect: "none",
-              bgcolor: "#fff",
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
-              transition: "transform 0.15s, box-shadow 0.15s, border-color 0.15s",
-              boxShadow: "0 1px 4px rgba(0,0,0,0.06)",
-              "&:hover": {
-                transform: "translateY(-2px)",
-                boxShadow: "0 4px 12px rgba(0,0,0,0.1)",
-                borderColor: "#B43D20",
-              },
-            }}
-          >
-            {options[idx]}
-          </Box>
-        ))}
-      </Box>
+      {/* Bank stays fully stocked: dropping copies a tile, it does not consume it. */}
+      {!showTileAudio && (
+        <Box
+          sx={{
+            display: "flex",
+            gap: 1.25,
+            p: 1.5,
+            borderRadius: "14px",
+            bgcolor: bankDragOver ? "rgba(96,165,250,0.08)" : "#F9F7F4",
+            border: `1px solid ${bankDragOver ? "#60A5FA" : "rgba(0,0,0,0.08)"}`,
+            minHeight: 76,
+            flexWrap: "wrap",
+            justifyContent: "center",
+            width: "100%",
+            transition: "border-color 0.2s, background-color 0.2s",
+          }}
+          onDragOver={(e) => {
+            e.preventDefault();
+            setBankDragOver(true);
+          }}
+          onDragLeave={() => setBankDragOver(false)}
+          onDrop={onDropBank}
+        >
+          {options.map((label, idx) => (
+            <Box
+              key={`bank-${idx}`}
+              draggable
+              onDragStart={(e) => onDragStart(e, { source: "bank", option: idx })}
+              title="Drag to the box above — you can use this tile more than once"
+              sx={{
+                px: 2.5,
+                py: 1.25,
+                border: "2px solid rgba(0,0,0,0.1)",
+                borderRadius: "12px",
+                cursor: "grab",
+                fontSize: { xs: "0.95rem", sm: "1.05rem" },
+                fontWeight: 700,
+                whiteSpace: "nowrap",
+                userSelect: "none",
+                bgcolor: "#fff",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                transition: "transform 0.15s, box-shadow 0.15s, border-color 0.15s",
+                boxShadow: "0 1px 4px rgba(0,0,0,0.06)",
+                "&:hover": {
+                  transform: "translateY(-2px)",
+                  boxShadow: "0 4px 12px rgba(0,0,0,0.1)",
+                  borderColor: "#B43D20",
+                },
+              }}
+            >
+              {label}
+            </Box>
+          ))}
+        </Box>
+      )}
 
       <Box sx={{ display: "flex", gap: 1.5, flexWrap: "wrap", justifyContent: "center" }}>
         <Box

--- a/src/features/exercises/components/DragDropCombination.tsx
+++ b/src/features/exercises/components/DragDropCombination.tsx
@@ -186,7 +186,6 @@ const DragDropCombination: React.FC<Props> = ({
   };
 
   const handleCheck = () => {
-    if (!isComplete) return;
     setChecked(true);
     onResult?.({
       result: isCorrect ? "correct" : "incorrect",
@@ -500,20 +499,19 @@ const DragDropCombination: React.FC<Props> = ({
         <Box
           component="button"
           onClick={handleCheck}
-          disabled={!isComplete}
           sx={{
             px: 3,
             py: 1.25,
             borderRadius: 999,
             border: "none",
-            bgcolor: isComplete ? "#B43D20" : "rgba(0,0,0,0.08)",
-            color: isComplete ? "#fff" : "rgba(0,0,0,0.35)",
+            bgcolor: "#B43D20",
+            color: "#fff",
             fontWeight: 700,
             fontSize: "0.9rem",
-            cursor: isComplete ? "pointer" : "default",
+            cursor: "pointer",
             transition: "all 0.2s",
-            boxShadow: isComplete ? "0 4px 14px rgba(180,61,32,0.35)" : "none",
-            "&:hover": isComplete ? { bgcolor: "#9D351C" } : {},
+            boxShadow: "0 4px 14px rgba(180,61,32,0.35)",
+            "&:hover": { bgcolor: "#9D351C" },
           }}
         >
           Check

--- a/src/features/exercises/components/DragDropCombination.tsx
+++ b/src/features/exercises/components/DragDropCombination.tsx
@@ -94,8 +94,21 @@ const DragDropCombination: React.FC<Props> = ({
 
   const onDragStart = (e: React.DragEvent<HTMLDivElement>, payload: DragPayload) => {
     dragPayloadRef.current = payload;
+    // `text/plain` is what Firefox needs to treat this as a real drag.
+    e.dataTransfer.setData("text/plain", options[payload.option] ?? "");
     e.dataTransfer.setData("application/json", JSON.stringify(payload));
     e.dataTransfer.effectAllowed = dropEffect(payload.source);
+    // A cloned ghost keeps the bank tile itself on screen. Native `move`
+    // hides the source node, which is exactly "the tile disappeared."
+    if (payload.source === "bank") {
+      const ghost = e.currentTarget.cloneNode(true) as HTMLElement;
+      ghost.style.position = "absolute";
+      ghost.style.top = "-9999px";
+      ghost.style.pointerEvents = "none";
+      document.body.appendChild(ghost);
+      e.dataTransfer.setDragImage(ghost, e.nativeEvent.offsetX, e.nativeEvent.offsetY);
+      window.setTimeout(() => ghost.remove(), 0);
+    }
   };
 
   const readPayload = (e: React.DragEvent<HTMLDivElement>): DragPayload | null => {
@@ -125,10 +138,8 @@ const DragDropCombination: React.FC<Props> = ({
           if (payload.placedAt < pos) pos -= 1;
           break;
         }
-        case "bank": {
-          if (next.length >= correctSequence.length) return next;
+        case "bank":
           break;
-        }
         default: {
           const _exhaustive: never = payload;
           return _exhaustive;
@@ -428,63 +439,62 @@ const DragDropCombination: React.FC<Props> = ({
         )}
       </Box>
 
-      {/* Bank stays fully stocked: dropping copies a tile, it does not consume it. */}
-      {!showTileAudio && (
-        <Box
-          sx={{
-            display: "flex",
-            gap: 1.25,
-            p: 1.5,
-            borderRadius: "14px",
-            bgcolor: bankDragOver ? "rgba(96,165,250,0.08)" : "#F9F7F4",
-            border: `1px solid ${bankDragOver ? "#60A5FA" : "rgba(0,0,0,0.08)"}`,
-            minHeight: 76,
-            flexWrap: "wrap",
-            justifyContent: "center",
-            width: "100%",
-            transition: "border-color 0.2s, background-color 0.2s",
-          }}
-          onDragOver={(e) => {
-            e.preventDefault();
-            setBankDragOver(true);
-          }}
-          onDragLeave={() => setBankDragOver(false)}
-          onDrop={onDropBank}
-        >
-          {options.map((label, idx) => (
-            <Box
-              key={`bank-${idx}`}
-              draggable
-              onDragStart={(e) => onDragStart(e, { source: "bank", option: idx })}
-              title="Drag to the box above — you can use this tile more than once"
-              sx={{
-                px: 2.5,
-                py: 1.25,
-                border: "2px solid rgba(0,0,0,0.1)",
-                borderRadius: "12px",
-                cursor: "grab",
-                fontSize: { xs: "0.95rem", sm: "1.05rem" },
-                fontWeight: 700,
-                whiteSpace: "nowrap",
-                userSelect: "none",
-                bgcolor: "#fff",
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "center",
-                transition: "transform 0.15s, box-shadow 0.15s, border-color 0.15s",
-                boxShadow: "0 1px 4px rgba(0,0,0,0.06)",
-                "&:hover": {
-                  transform: "translateY(-2px)",
-                  boxShadow: "0 4px 12px rgba(0,0,0,0.1)",
-                  borderColor: "#B43D20",
-                },
-              }}
-            >
-              {label}
-            </Box>
-          ))}
-        </Box>
-      )}
+      {/* Always the full set — dropping copies a tile, it does not consume it. */}
+      <Box
+        sx={{
+          display: "flex",
+          gap: 1.25,
+          p: 1.5,
+          borderRadius: "14px",
+          bgcolor: bankDragOver ? "rgba(96,165,250,0.08)" : "#F9F7F4",
+          border: `1px solid ${bankDragOver ? "#60A5FA" : "rgba(0,0,0,0.08)"}`,
+          minHeight: 76,
+          flexWrap: "wrap",
+          justifyContent: "center",
+          width: "100%",
+          transition: "border-color 0.2s, background-color 0.2s",
+        }}
+        onDragOver={(e) => {
+          e.preventDefault();
+          setBankDragOver(true);
+        }}
+        onDragLeave={() => setBankDragOver(false)}
+        onDrop={onDropBank}
+      >
+        {options.map((label, idx) => (
+          <Box
+            key={`bank-${idx}`}
+            draggable
+            onDragStart={(e) => onDragStart(e, { source: "bank", option: idx })}
+            title="Drag to the box above — you can use this tile more than once"
+            sx={{
+              px: 2.5,
+              py: 1.25,
+              border: "2px solid rgba(0,0,0,0.1)",
+              borderRadius: "12px",
+              cursor: "grab",
+              fontSize: { xs: "0.95rem", sm: "1.05rem" },
+              fontWeight: 700,
+              whiteSpace: "nowrap",
+              userSelect: "none",
+              bgcolor: "#fff",
+              opacity: 1,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              transition: "transform 0.15s, box-shadow 0.15s, border-color 0.15s",
+              boxShadow: "0 1px 4px rgba(0,0,0,0.06)",
+              "&:hover": {
+                transform: "translateY(-2px)",
+                boxShadow: "0 4px 12px rgba(0,0,0,0.1)",
+                borderColor: "#B43D20",
+              },
+            }}
+          >
+            {label}
+          </Box>
+        ))}
+      </Box>
 
       <Box sx={{ display: "flex", gap: 1.5, flexWrap: "wrap", justifyContent: "center" }}>
         <Box

--- a/src/features/exercises/components/MatchAudioExercisePlaceholder.tsx
+++ b/src/features/exercises/components/MatchAudioExercisePlaceholder.tsx
@@ -18,8 +18,11 @@ export interface MatchAudioItem {
   audioUrl?: string;
   imageUrl?: string;
   // Other terms learned since the last checkpoint (or since the start of the
-  // lesson) — the pool the 2 wrong-answer images are drawn from.
+  // lesson) — the pool the 2 wrong answers are drawn from.
   checkpointPool?: ChoiceCandidate[];
+  /** Authored on the block: written characters vs pictures. */
+  answerWith?: "text" | "image";
+  prompt?: string;
 }
 
 interface Props {
@@ -29,6 +32,19 @@ interface Props {
 
 function isPlaceholder(url?: string) {
   return !url || url.toUpperCase().includes("PLACEHOLDER");
+}
+
+function defaultPrompt(answerWith: "text" | "image"): string {
+  switch (answerWith) {
+    case "image":
+      return "Which situation matches this phrase?";
+    case "text":
+      return "Listen and choose the character you hear";
+    default: {
+      const _exhaustive: never = answerWith;
+      return _exhaustive;
+    }
+  }
 }
 
 // The correct term plus up to 2 random, DISTINCT distractors from the
@@ -41,6 +57,56 @@ function buildChoices(item: MatchAudioItem): ChoiceCandidate[] {
   return buildChoiceOptions(correct, item.checkpointPool ?? [], 2);
 }
 
+function ChoiceFace({
+  answerWith,
+  phrase,
+  imageUrl,
+}: {
+  answerWith: "text" | "image";
+  phrase: string;
+  imageUrl?: string;
+}): React.ReactElement {
+  switch (answerWith) {
+    case "text":
+      return (
+        <Typography
+          sx={{
+            fontSize: { xs: "2.4rem", sm: "2.8rem" },
+            fontWeight: 800,
+            color: "#1C1917",
+            lineHeight: 1,
+            userSelect: "none",
+          }}
+        >
+          {phrase}
+        </Typography>
+      );
+    case "image":
+      if (!isPlaceholder(imageUrl)) {
+        return (
+          <Box
+            component="img"
+            src={imageUrl}
+            alt=""
+            sx={{ width: "100%", height: "100%", objectFit: "cover", position: "absolute", inset: 0 }}
+          />
+        );
+      }
+      return (
+        <>
+          <ImageRoundedIcon sx={{ fontSize: "2rem", color: "rgba(0,0,0,0.18)" }} />
+          <Typography sx={{ fontSize: "0.65rem", color: "text.disabled", textAlign: "center", px: 0.5 }}>
+            Image soon
+          </Typography>
+        </>
+      );
+    default: {
+      const _exhaustive: never = answerWith;
+      return _exhaustive;
+    }
+  }
+}
+
 const MatchAudioExercisePlaceholder: React.FC<Props> = ({ item, onResult }) => {
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const [playing, setPlaying] = useState(false);
@@ -48,6 +114,8 @@ const MatchAudioExercisePlaceholder: React.FC<Props> = ({ item, onResult }) => {
   const [wrongFlash, setWrongFlash] = useState<string | null>(null);
 
   const hasAudio = !isPlaceholder(item.audioUrl);
+  const answerWith = item.answerWith ?? "text";
+  const prompt = item.prompt || defaultPrompt(answerWith);
 
   const playAudio = () => {
     if (!hasAudio || !audioRef.current) return;
@@ -100,7 +168,6 @@ const MatchAudioExercisePlaceholder: React.FC<Props> = ({ item, onResult }) => {
         />
       )}
 
-      {/* Audio button */}
       {hasAudio && (
         <audio
           ref={audioRef}
@@ -112,60 +179,41 @@ const MatchAudioExercisePlaceholder: React.FC<Props> = ({ item, onResult }) => {
       <Box
         onClick={playAudio}
         sx={{
+          width: 72,
+          height: 72,
+          borderRadius: "50%",
+          bgcolor: hasAudio ? BRAND : "rgba(0,0,0,0.12)",
           display: "flex",
-          flexDirection: "column",
           alignItems: "center",
-          gap: 1,
+          justifyContent: "center",
           cursor: hasAudio ? "pointer" : "default",
-        }}
-      >
-        <Box
-          sx={{
-            width: 72,
-            height: 72,
-            borderRadius: "50%",
-            bgcolor: hasAudio ? BRAND : "rgba(0,0,0,0.12)",
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            boxShadow: playing
-              ? "0 0 0 0 transparent"
-              : hasAudio
+          boxShadow: playing
+            ? "0 0 0 0 transparent"
+            : hasAudio
               ? "0 4px 16px rgba(180,61,32,0.35)"
               : "none",
-            animation: playing ? "audioPulse 1.2s ease-in-out infinite" : "none",
-            "@keyframes audioPulse": {
-              "0%,100%": { boxShadow: "0 0 0 0 rgba(180,61,32,0.4)" },
-              "50%": { boxShadow: "0 0 0 16px rgba(180,61,32,0)" },
-            },
-            transition: "box-shadow 0.3s",
-          }}
-        >
-          {playing
-            ? <GraphicEqRoundedIcon sx={{ color: "#fff", fontSize: "2rem" }} />
-            : <VolumeUpRoundedIcon sx={{ color: hasAudio ? "#fff" : "rgba(0,0,0,0.3)", fontSize: "2rem" }} />}
-        </Box>
-
-        {/* Phrase label — small, below audio button */}
-        <Typography
-          sx={{ fontSize: "0.78rem", fontWeight: 700, color: "text.secondary", letterSpacing: "0.02em" }}
-        >
-          {item.phrase}
-        </Typography>
+          animation: playing ? "audioPulse 1.2s ease-in-out infinite" : "none",
+          "@keyframes audioPulse": {
+            "0%,100%": { boxShadow: "0 0 0 0 rgba(180,61,32,0.4)" },
+            "50%": { boxShadow: "0 0 0 16px rgba(180,61,32,0)" },
+          },
+          transition: "box-shadow 0.3s",
+        }}
+      >
+        {playing
+          ? <GraphicEqRoundedIcon sx={{ color: "#fff", fontSize: "2rem" }} />
+          : <VolumeUpRoundedIcon sx={{ color: hasAudio ? "#fff" : "rgba(0,0,0,0.3)", fontSize: "2rem" }} />}
       </Box>
 
-      {/* Prompt */}
       <Typography
         sx={{ fontWeight: 700, fontSize: "0.92rem", color: "#1C1917" }}
       >
-        Which situation matches this phrase?
+        {prompt}
       </Typography>
 
-      {/* Three image choice buttons */}
       <Box sx={{ display: "flex", gap: { xs: 1, sm: 2 }, width: "100%", justifyContent: "center" }}>
         {choices.map((choice, i) => {
           const state = getState(choice);
-          const hasImg = !isPlaceholder(choice.imageUrl);
 
           return (
             <Box
@@ -201,21 +249,7 @@ const MatchAudioExercisePlaceholder: React.FC<Props> = ({ item, onResult }) => {
                 },
               }}
             >
-              {hasImg ? (
-                <Box
-                  component="img"
-                  src={choice.imageUrl}
-                  alt={choice.phrase}
-                  sx={{ width: "100%", height: "100%", objectFit: "cover", position: "absolute", inset: 0 }}
-                />
-              ) : (
-                <>
-                  <ImageRoundedIcon sx={{ fontSize: "2rem", color: "rgba(0,0,0,0.18)" }} />
-                  <Typography sx={{ fontSize: "0.65rem", color: "text.disabled", textAlign: "center", px: 0.5 }}>
-                    Image soon
-                  </Typography>
-                </>
-              )}
+              <ChoiceFace answerWith={answerWith} phrase={choice.phrase} imageUrl={choice.imageUrl} />
 
               {/* Result overlay */}
               {state !== "idle" && (

--- a/src/features/exercises/components/RenderBlock.tsx
+++ b/src/features/exercises/components/RenderBlock.tsx
@@ -461,6 +461,8 @@ const MatchPairsView: React.FC<MatchPairsBlock & { onResult?: ResultCallback }> 
 const ListenAndChooseView: React.FC<ListenAndChooseBlock & { onResult?: ResultCallback }> = ({
   term: correct,
   distractors,
+  answerWith,
+  instructions,
   onResult,
 }) => {
   const pool = (distractors ?? [])
@@ -477,6 +479,8 @@ const ListenAndChooseView: React.FC<ListenAndChooseBlock & { onResult?: ResultCa
         audioUrl: termAudio(correct),
         imageUrl: termImage(correct),
         checkpointPool: pool.length ? pool : undefined,
+        answerWith,
+        prompt: instructions?.trim(),
       }}
       onResult={onResult}
     />
@@ -512,31 +516,9 @@ const BuildSentenceView: React.FC<
     return termAudio(match);
   };
 
-  /*
-   * Some authored answers repeat a character — "おおい" needs お twice — but
-   * the tile bank was authored with one of each, which makes the puzzle
-   * impossible to actually place: the second お simply is not there to drag.
-   * Padded rather than fixed in the content, because the same authoring
-   * habit (one tile per distinct kana) is likely elsewhere too and this
-   * makes every instance of it solvable rather than only the ones noticed.
-   * Extra tiles are appended after the authored set so the original bank
-   * order is otherwise unchanged.
-   */
-  const withEnoughTiles = (available: string[], needed: string[]): string[] => {
-    const have = new Map<string, number>();
-    for (const t of available) have.set(t, (have.get(t) ?? 0) + 1);
-
-    const extra: string[] = [];
-    const seen = new Map<string, number>();
-    for (const n of needed) {
-      const count = (seen.get(n) ?? 0) + 1;
-      seen.set(n, count);
-      if (count > (have.get(n) ?? 0)) extra.push(n);
-    }
-    return extra.length ? [...available, ...extra] : available;
-  };
-
-  const resolvedTiles = withEnoughTiles(tiles ?? [], correctSequence ?? []);
+  // Distinct tiles only — DragDropCombination copies from the bank, so a
+  // repeated character ("おおい") does not need a duplicate option.
+  const resolvedTiles = [...new Set(tiles ?? [])];
 
   return (
     <DragDropCombination

--- a/src/features/learning/components/TermReviewPage.tsx
+++ b/src/features/learning/components/TermReviewPage.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import React from "react";
-import { Box, Container, Typography } from "@mui/material";
+import { Box, Container, IconButton, Typography } from "@mui/material";
 import ArrowBackRoundedIcon from "@mui/icons-material/ArrowBackRounded";
+import ChevronLeftRoundedIcon from "@mui/icons-material/ChevronLeftRounded";
+import ChevronRightRoundedIcon from "@mui/icons-material/ChevronRightRounded";
 import Link from "next/link";
 
 import TermCard from "@/features/learning/components/TermCard";
@@ -11,9 +13,50 @@ import type { Lesson, Term } from "@/payload/payload-types";
 
 const BRAND = "#B43D20";
 
-const TermReviewPage: React.FC<{ lesson: Lesson; terms: Term[] }> = ({ lesson, terms }) => (
+const arrowSx = {
+  color: "text.secondary",
+  "&:hover": { color: BRAND, bgcolor: "rgba(180,61,32,0.08)" },
+} as const;
+
+function NeighborArrow({
+  href,
+  label,
+  Icon,
+}: {
+  href?: string;
+  label: string;
+  Icon: typeof ChevronLeftRoundedIcon;
+}) {
+  if (!href) return <Box sx={{ width: 48 }} />;
+
+  return (
+    <IconButton component={Link} href={href} aria-label={label} size="small" sx={arrowSx}>
+      <Icon fontSize="large" />
+    </IconButton>
+  );
+}
+
+const TermReviewPage: React.FC<{
+  lesson: Lesson;
+  terms: Term[];
+  prevHref?: string;
+  nextHref?: string;
+}> = ({ lesson, terms, prevHref, nextHref }) => (
   <Box sx={{ minHeight: "100vh", bgcolor: "#F9F7F4" }}>
-    <Container maxWidth="md" sx={{ pt: 5, pb: 8 }}>
+    <Container maxWidth="md" sx={{ pt: 3, pb: 8 }}>
+      <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center", mb: 1 }}>
+        <NeighborArrow
+          href={prevHref}
+          label="Previous lesson review"
+          Icon={ChevronLeftRoundedIcon}
+        />
+        <NeighborArrow
+          href={nextHref}
+          label="Next lesson review"
+          Icon={ChevronRightRoundedIcon}
+        />
+      </Box>
+
       <Box
         component={Link}
         href={lessonHref(lesson.slug)}

--- a/src/lib/content/content.ts
+++ b/src/lib/content/content.ts
@@ -3,7 +3,7 @@ import { unstable_cache } from "next/cache";
 import type { TypedUser, Where } from "payload";
 import { payloadClient } from "./payload";
 import { TAGS } from "./tags";
-import { lessonHref } from "./routes";
+import { lessonHref, lessonReviewHref } from "./routes";
 import { CONTENT_DEPTH, MEDIA_POPULATE } from "./depth";
 import type { Lesson, Resource } from "../../payload/payload-types";
 
@@ -161,45 +161,111 @@ export function getLessonBySlug(slugOrLegacyId: string): Promise<Lesson | null> 
  * wrong player. And it no longer filters to step lessons only, which is what
  * made that latent: both formats have course order, and both now use it.
  */
-export function getNextLessonHref(lesson: Lesson): Promise<string | undefined> {
-  const courseId = typeof lesson.course === "object" ? lesson.course?.id : lesson.course;
-  if (
-    courseId === null ||
-    courseId === undefined ||
-    lesson.order === null ||
-    lesson.order === undefined
-  ) {
-    return Promise.resolve(undefined);
-  }
+type Neighbor = "next" | "prev";
 
-  const order = lesson.order;
+function coursePlacement(lesson: Lesson): { courseId: number | string; order: number } | null {
+  const courseId = typeof lesson.course === "object" ? lesson.course?.id : lesson.course;
+  if (courseId === null || courseId === undefined || lesson.order === null || lesson.order === undefined) {
+    return null;
+  }
+  return { courseId, order: lesson.order };
+}
+
+function neighborDirection(
+  order: number,
+  neighbor: Neighbor
+): { clause: { greater_than: number } | { less_than: number }; sort: "order" | "-order" } {
+  switch (neighbor) {
+    case "next":
+      return { clause: { greater_than: order }, sort: "order" };
+    case "prev":
+      return { clause: { less_than: order }, sort: "-order" };
+    default: {
+      const _exhaustive: never = neighbor;
+      return _exhaustive;
+    }
+  }
+}
+
+async function findNeighborSlug(args: {
+  courseId: number | string;
+  format: Lesson["format"];
+  order: number;
+  neighbor: Neighbor;
+  publishedOnly: boolean;
+  user?: TypedUser;
+}): Promise<string | undefined> {
+  const { clause, sort } = neighborDirection(args.order, args.neighbor);
+  const neighborWhere: Where = {
+    format: { equals: args.format },
+    course: { equals: args.courseId },
+    order: clause,
+  };
+
+  const payload = await payloadClient();
+  const result = await payload.find({
+    collection: "lessons",
+    where: args.publishedOnly ? and(PUBLISHED, neighborWhere) : and(neighborWhere),
+    limit: 1,
+    // Deliberately 0: this reads two fields, `slug` and `format`.
+    depth: 0,
+    sort,
+    overrideAccess: false,
+    ...(args.publishedOnly ? {} : { draft: true, user: args.user }),
+  });
+
+  return result.docs[0]?.slug;
+}
+
+/**
+ * Published neighbour lookup. Whole-collection tags, not a per-slug one:
+ * this answer changes when a *different* lesson is added, reordered or unpublished.
+ */
+function getPublishedNeighborHref(
+  lesson: Lesson,
+  neighbor: Neighbor,
+  toHref: (slug: string) => string,
+  cacheKey: readonly string[]
+): Promise<string | undefined> {
+  const placement = coursePlacement(lesson);
+  if (!placement) return Promise.resolve(undefined);
+
+  const { courseId, order } = placement;
   const format = lesson.format;
 
   return unstable_cache(
     async (): Promise<string | undefined> => {
-      const payload = await payloadClient();
-      const result = await payload.find({
-        collection: "lessons",
-        where: and(PUBLISHED, {
-          format: { equals: format },
-          course: { equals: courseId },
-          order: { greater_than: order },
-        }),
-        limit: 1,
-        // Deliberately 0: this reads two fields, `slug` and `format`.
-        depth: 0,
-        sort: "order",
-        overrideAccess: false,
+      const slug = await findNeighborSlug({
+        courseId,
+        format,
+        order,
+        neighbor,
+        publishedOnly: true,
       });
-
-      const next = result.docs[0];
-      return next ? lessonHref(next.slug) : undefined;
+      return slug ? toHref(slug) : undefined;
     },
-    ["content", "getNextLessonHref", String(courseId), String(format), String(order)],
-    // The whole-collection tags, not a per-slug one: this answer changes when a
-    // *different* lesson is added, reordered or unpublished.
+    [...cacheKey, String(courseId), String(format), String(order)],
     { tags: [TAGS.lessons, TAGS.newLessons], revalidate: REVALIDATE }
   )();
+}
+
+export function getNextLessonHref(lesson: Lesson): Promise<string | undefined> {
+  return getPublishedNeighborHref(lesson, "next", lessonHref, [
+    "content",
+    "getNextLessonHref",
+  ]);
+}
+
+/** The neighbouring lesson's term-review page, same course and format. */
+export function getNeighborLessonReviewHref(
+  lesson: Lesson,
+  neighbor: Neighbor
+): Promise<string | undefined> {
+  return getPublishedNeighborHref(lesson, neighbor, lessonReviewHref, [
+    "content",
+    "getNeighborLessonReviewHref",
+    neighbor,
+  ]);
 }
 
 // ── Resources ────────────────────────────────────────────────────────────────
@@ -349,36 +415,39 @@ export async function getDraftLesson(
  * they just added as the one that follows, not skip over it to the last
  * published one.
  */
-export async function getDraftNextHref(
+async function getDraftNeighborHref(
+  lesson: Lesson,
+  user: TypedUser,
+  neighbor: Neighbor,
+  toHref: (slug: string) => string
+): Promise<string | undefined> {
+  const placement = coursePlacement(lesson);
+  if (!placement) return undefined;
+
+  const slug = await findNeighborSlug({
+    courseId: placement.courseId,
+    format: lesson.format,
+    order: placement.order,
+    neighbor,
+    publishedOnly: false,
+    user,
+  });
+  return slug ? toHref(slug) : undefined;
+}
+
+export function getDraftNextHref(
   lesson: Lesson,
   user: TypedUser
 ): Promise<string | undefined> {
-  const courseId = typeof lesson.course === "object" ? lesson.course?.id : lesson.course;
-  if (courseId === null || courseId === undefined || lesson.order === null || lesson.order === undefined) {
-    return undefined;
-  }
+  return getDraftNeighborHref(lesson, user, "next", lessonHref);
+}
 
-  const payload = await payloadClient();
-  const result = await payload.find({
-    collection: "lessons",
-    where: and({
-      // Matches `getNextLessonHref`: the next lesson of the same format, not the
-      // next step lesson regardless of what this one is.
-      format: { equals: lesson.format },
-      course: { equals: courseId },
-      order: { greater_than: lesson.order },
-    }),
-    limit: 1,
-    // Deliberately 0, as on the published path above.
-    depth: 0,
-    draft: true,
-    sort: "order",
-    overrideAccess: false,
-    user,
-  });
-
-  const next = result.docs[0];
-  return next ? lessonHref(next.slug) : undefined;
+export function getDraftNeighborLessonReviewHref(
+  lesson: Lesson,
+  user: TypedUser,
+  neighbor: Neighbor
+): Promise<string | undefined> {
+  return getDraftNeighborHref(lesson, user, neighbor, lessonReviewHref);
 }
 
 export async function getDraftResources(user: TypedUser): Promise<Resource[]> {


### PR DESCRIPTION
## Summary
- Add prev/next arrows on the term review page so learners can move between adjacent lessons’ review screens.
- Honor listen-and-choose `answerWith`: character tiles vs pictures, no phrase under the speaker. Lesson 1’s first four screens are situation matching (`あお` / `うえ` / `あう` / `おおい`) with “Which situation matches this phrase?”
- Keep drag-drop bank tiles on screen (copy, not consume), allow Check with any number of tiles, and turn every option into a hear-button after a correct answer.

## Test plan
- [ ] Open a lesson review page and confirm prev/next go to neighboring lessons’ `/lessons/<slug>/review` (first/last lesson has no arrow on that side).
- [ ] Reading/writing lesson 1: first four listen-and-choose screens use the situation prompt and term images; the fifth is still “Listen and choose the character you hear.”
- [ ] A later listen-and-choose with `answerWith: text` still shows large kana, not pictures.
- [ ] Drag-drop: bank tiles stay after use; the same character can be dropped more than once; Check is always enabled; wrong length grades incorrect; after a correct answer, all tiles become hear-buttons.


Made with [Cursor](https://cursor.com)